### PR TITLE
pytest-jupyter 0.10.1 b1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+# disable tests due to circular dependency with jupyter_client and jupyter_server
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--no-test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 00df54eef9e201dd542d5471b8980def15d34b917b30587d14d7c824fc4d9e84
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 requirements:


### PR DESCRIPTION
Enable 3.13. Rebuild with tests disable to circumvent circular dependency with jupyter_server.