### PR TITLE
Rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
-# disable tests due to circular dependency with jupyter_client and jupyter_server
+# disable tests due to circular dependency with jupyter_client and jupyter_server.
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ outputs:
       requires:
         - python
         - pip
+
   - name: pytest-jupyter-client
     requirements:
       host:
@@ -64,6 +65,7 @@ outputs:
         - pip check
       requires:
         - pip
+
   - name: pytest-jupyter-server
     requirements:
       host:


### PR DESCRIPTION
Re-trigger CI because https://github.com/AnacondaRecipes/pytest-jupyter-feedstock/pull/6 failed after merging.